### PR TITLE
Allow port reuse

### DIFF
--- a/App.config
+++ b/App.config
@@ -10,9 +10,6 @@
             <setting name="IL2TelemetryPort" serializeAs="String">
                 <value>4322</value>
             </setting>
-            <setting name="IL2MotionPort" serializeAs="String">
-                <value>4321</value>
-            </setting>
             <setting name="WWPort" serializeAs="String">
                 <value>16536</value>
             </setting>

--- a/Program.cs
+++ b/Program.cs
@@ -23,10 +23,8 @@ namespace IL2WinWing
 
     public class CustomAppContext : ApplicationContext
     {
-        private UdpClient telemetryClient = new UdpClient(Properties.Settings.Default.IL2TelemetryPort);
-        private UdpClient motionClient = new UdpClient(Properties.Settings.Default.IL2MotionPort);
+        private UdpClient telemetryClient = new UdpClient();
         private IPEndPoint teleEP = new IPEndPoint(IPAddress.Parse("127.0.0.1"), Properties.Settings.Default.IL2TelemetryPort);
-        //private IPEndPoint motionEP = new IPEndPoint(IPAddress.Parse("127.0.0.1"), Properties.Settings.Default.IL2MotionPort);
 
         private IL2Protocol.Motion motion = new IL2Protocol.Motion();
         private int gunShells = 1000;
@@ -49,6 +47,10 @@ namespace IL2WinWing
             trayIcon.ContextMenuStrip.Items.Add("-");
             trayIcon.ContextMenuStrip.Items.Add("Exit", null, Exit);
             trayIcon.Visible = true;
+
+            telemetryClient.ExclusiveAddressUse = false;
+            telemetryClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            telemetryClient.Client.Bind(teleEP);
 
             new Task(IL2Listener).Start();
             wwAPI.WWMessageReceived += OnWWMessage;
@@ -103,21 +105,6 @@ namespace IL2WinWing
                         }
                     }
 
-                    //bytes = motionClient.Receive(ref motionEP);
-
-                    //if (bytes.Length > 0)
-                    //{
-                    //    if (!wwAPI.wwInit && !waitingForWWInit)
-                    //    {
-                    //        waitingForWWInit = true;
-                    //        wwAPI.Send(WWAPI.WWMessage.START);
-                    //    }
-                    //    else
-                    //    {
-                    //        ParseIL2Message(bytes);
-                    //    }
-                    //}
-
                     Thread.Sleep(25);
                 }
             }
@@ -129,7 +116,6 @@ namespace IL2WinWing
             {
                 run = false;
                 telemetryClient.Close();
-                motionClient.Close();
             }
         }
 

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace IL2WinWing.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.8.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.9.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -29,15 +29,6 @@ namespace IL2WinWing.Properties {
         public int IL2TelemetryPort {
             get {
                 return ((int)(this["IL2TelemetryPort"]));
-            }
-        }
-        
-        [global::System.Configuration.ApplicationScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("4321")]
-        public int IL2MotionPort {
-            get {
-                return ((int)(this["IL2MotionPort"]));
             }
         }
         

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -5,9 +5,6 @@
     <Setting Name="IL2TelemetryPort" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">4322</Value>
     </Setting>
-    <Setting Name="IL2MotionPort" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">4321</Value>
-    </Setting>
     <Setting Name="WWPort" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">16536</Value>
     </Setting>


### PR DESCRIPTION
The UDP client for telemetry data now allows the port to be reused by other processes (like SRS). Also removed UDP client for motion data since it wasn't used and could be interfering with SimShaker.